### PR TITLE
Fix NavigableString error

### DIFF
--- a/za_parliament_scrapers/questions.py
+++ b/za_parliament_scrapers/questions.py
@@ -344,7 +344,7 @@ class QuestionAnswerScraper(object):
                 if self.REPLY_RE.match(p.text):
                     for el in list(p.previous_elements):
                         if isinstance(el, bs4.element.Tag):
-                            el.decompose()
+                            el.extract()
                     p.decompose()
                     break
 

--- a/za_parliament_scrapers/questions.py
+++ b/za_parliament_scrapers/questions.py
@@ -345,7 +345,7 @@ class QuestionAnswerScraper(object):
                     for el in list(p.previous_elements):
                         if isinstance(el, bs4.element.Tag):
                             el.extract()
-                    p.decompose()
+                    p.extract()
                     break
 
             return str(soup)


### PR DESCRIPTION
[Error on Sentry](https://sentry.io/organizations/openupsa/issues/1709956995/?project=1489874&query=is%3Aunresolved)

Looks like `decompose` raises an error when trying to delete a tag that contains a `NavigableString`, so rather use `extract` that can delete either type.

This fixes the uploading of certain question documents on PA.

[SO answer](https://stackoverflow.com/a/58027044/3486675)

[Pivotal](https://www.pivotaltracker.com/story/show/173500049)